### PR TITLE
SSG Feature: Support --config with Config File

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+    "input": "./input_data/Sherlock-Holmes-Selected-Stories/Silver Blaze.txt",
+    "output": "./dist",
+    "stylesheet": "https://cdn.delivr.net/npm/water.css@2/out/water.css",
+    "lang": "fr"
+}
+  

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,7 @@
 import fs, { stat } from 'fs';
 import path from 'path';
 import readline from 'readline';
+import configStyle from './main.js';
 
 const dist_path = "./dist";
 var htmlLangAttribute = "en-CA";
@@ -41,7 +42,7 @@ function setOutputFolder(outputDir) {
     makeOutputFolder(outputPath.valueOf());
 }
 
-export function generateWebsite(inputStr, outputStr)
+export function generateWebsite(inputStr, outputStr, configStyle= '')
 {
     setOutputFolder(outputStr);
     parseFile(inputStr, outputStr);
@@ -208,8 +209,11 @@ function writeHtmlFile(fileName, outputDir, dataArr) {
             myBuffer = "";
         }
 
+       
 
-        const htmlStr = generateHtmlPage(title, htmlBody);
+        
+
+        const htmlStr = generateHtmlPage(title, htmlBody, configStyle);
 
         // Write the html file contents ('htmlStr') to the specified file path
         fs.writeFile(htmlFilePath, htmlStr, (err)=>{
@@ -225,7 +229,7 @@ function writeHtmlFile(fileName, outputDir, dataArr) {
 }
 
 // Generates the index.html file.
-function generateIndexHtmlFile(filenames, outputDir) {
+function generateIndexHtmlFile(filenames, outputDir, configStyle) {
     const indexFilePath = outputDir + "/index.html";
     const indexTitle = "AP21 SSG";
 
@@ -262,20 +266,42 @@ function generateIndexHtmlFile(filenames, outputDir) {
 }
 
 // Generates the HTML string for a webpage for a single file.
-function generateHtmlPage(title, paragraphs) {
-    var str = `<!doctype html>
+function generateHtmlPage(title, paragraphs, configStyle) {
+    if(configStyle) 
+    {
+
+        var str = `<!doctype html>
         <html lang="${htmlLangAttribute}">
         <head>
-            <meta charset="utf-8">
-            <title>${title}</title>
-            <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta charset="utf-8">
+        <title>${title}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="${configStyle}"/>
         </head>
         <body>
-            <h1>${title}</h1>
-            ${paragraphs}
+        <h1>${title}</h1>
+        ${paragraphs}
         </body>
         </html>`;
+        
+    }
 
+    else 
+    {
+        var str = `<!doctype html>
+        <html lang="${htmlLangAttribute}">
+        <head>
+        <meta charset="utf-8">
+        <title>${title}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        </head>
+        <body>
+        <h1>${title}</h1>
+        ${paragraphs}
+        </body>
+        </html>`;
+        
+    }
     return str;
 }
 

--- a/main.js
+++ b/main.js
@@ -8,15 +8,32 @@ const program = new Command();
 const { version } = require('./package.json');
 const help_message = generateHelpMessage();
 
+const data = require('./config.json');
+
+const configInput = data.input || '';
+const configOutput = data.output || './dist';
+const configStyle = data.stylesheet;
+const configLang = data.lang || 'en';
+
 program.option('-i --input <item>', 'get input')
 	.option('-v --version', 'displays the program name & version number')
 	.option('-h --help', 'displays help message')
 	.option('-l --lang <item>', 'specify the language of the html documents')
-	.option('-o --output <item>', 'specify the output folder where the html files will be generated');
+	.option('-o --output <item>', 'specify the output folder where the html files will be generated')
+	.option('-c --config <item>', 'specify the config file that will contain all SSG options');
 
 program.parse(process.argv);
 
 const options = program.opts();
+
+if(options.config) 
+{
+    generateWebsite(`${configInput}`, `${configOutput}`, `${configStyle || ''}`);
+    setHtmlLang(`${configLang}`);
+}
+
+if(!options.config) 
+{
 
 if (options.version)
 {
@@ -31,7 +48,7 @@ if (options.help)
 if (options.input)
 {
     if (options.output) {
-        generateWebsite(`${options.input}`, `${options.output}`);
+        generateWebsite(`${options.input} `, `${options.output}`);
     }
     else {
         generateWebsite(`${options.input}`, '');
@@ -42,6 +59,9 @@ if (options.lang)
 {
     setHtmlLang(`${options.lang}`);
 }
+
+}
+
 
 function generateHelpMessage()
 {
@@ -58,8 +78,11 @@ function generateHelpMessage()
     helpMsg += `  -v --version               display the program name & version number\n`;
     helpMsg += `  -h, --help                 display this help message\n`;
     helpMsg += `  -i, --input                get input from a specified file or folder\n`;
+    helpMsg += `  -c, --config               specify the config file that will contain all SSG options\n`;
     helpMsg += `----------------------------------------------------------------------\n\n`;
 
 
 	return helpMsg;
 }
+
+export default configStyle;


### PR DESCRIPTION
Hi Arryell ,

I Added config file support feature for the following issue #24 .

Now, user can specify a config file that will contain all the SSG options instead of passing them all as command line arguments.

# For example:

`node main.js --config ./config.json `
